### PR TITLE
Add collapsible lesson sections

### DIFF
--- a/frontend/src/components/LessonViewer/CollapsibleSection.tsx
+++ b/frontend/src/components/LessonViewer/CollapsibleSection.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+interface CollapsibleSectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+export default function CollapsibleSection({ title, children }: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mb-4 border rounded-lg">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex justify-between items-center px-4 py-2 bg-gray-100 hover:bg-gray-200 font-semibold text-left"
+      >
+        <span>{title}</span>
+        <ChevronDown
+          className={`h-4 w-4 transform transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          className="p-4 bg-white"
+        >
+          {children}
+        </motion.div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `CollapsibleSection` component
- render lesson markdown in collapsible sections when headings are present

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build` *(fails: Cannot find module and TS errors)*
- `npm --prefix frontend run lint` *(fails: 63 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856518a1fa88326943bf68a81395691